### PR TITLE
we need to unmount isos before containers exit

### DIFF
--- a/scripts/run-mrepo.sh
+++ b/scripts/run-mrepo.sh
@@ -45,3 +45,8 @@ if [ ${WEB} ]; then
     echo 'Starting Apache...'
     exec /usr/sbin/apachectl -D FOREGROUND
 fi
+
+#if we made it this far, we're exiting (mrepo finished its update, or apache exited)
+#so lets unmount any isos mrepo had mounted as to not eat all the /dev/loop devices
+/usr/bin/mrepo --unmount -vvv 
+


### PR DESCRIPTION
Running an update leaves isos mounted (if running un priv'd mode), and afre a handful you'll run out of loop devices. running --unmount after an update/if apache exists should fix this.  
